### PR TITLE
homeのキャッチコピーを変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,8 +199,5 @@ DEPENDENCIES
   web-console
   will_paginate
 
-RUBY VERSION
-   ruby 2.2.4p230
-
 BUNDLED WITH
    1.13.6

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -3,7 +3,7 @@
     <div class="bs-component">
       <div class="jumbotron">
         <h1><%= fa_icon("wrench", text: base_title) %></h1>
-        <p>キャッチコピーなどをここに記入する</p>
+        <p>全29大会のロボット名をほぼ網羅</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
トップページに表示されるキャッチコピーを「全29大会のロボット名をほぼ網羅」に変更しました。