### PR TITLE
Revert "本番環境でdb:resetができるように設定変更"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,5 @@ module RoboconDb
     # -- all .rb files in that directory are automatically loaded.
 
     config.i18n.default_locale = :ja
-    ActiveRecord::Base.protected_environments = []
   end
 end


### PR DESCRIPTION
This reverts commit 84e1ce31cfa7290ffb02406cbc1d73cd3b547ab5.

この設定にかかわらず、
http://blog.aripei.com/2013/10/rails-operation-in-heoku.html
にある`heroku pg:reset DATABASE`で解決できることがわかったのでもとに戻しておきます。