### PR TITLE
MIT License他追加

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,5 +1,3 @@
 Authors ordered by first contribution to THIS SOFTWARE.
 
 Matthew238 / Ken-ichi AKIMOTO <matthew.szulik@gmail.com>
-m_cre / Shinya FUJITA <>
-takeo.hatakeyama <>


### PR DESCRIPTION
LICENSE.txtの他にAUTHORS.txtを貢献者リスト代わりに加えました。まだ他の方は加えていませんが、合意された方を載せたいと思います。また、仮称ですが「高専ロボコンデータベース製作委員会」という名称で代表させてもよいとおもっていますが、今後議論したいと思います。とりあえずは体裁を整えたいと思います。