### PR TITLE
add: 試合とその詳細(game detail)の情報を表示する機能を追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,4 +217,4 @@ RUBY VERSION
    ruby 2.2.6p396
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/app/assets/javascripts/games.coffee
+++ b/app/assets/javascripts/games.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/games.scss
+++ b/app/assets/stylesheets/games.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Games controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,5 @@
+class GamesController < ApplicationController
+  def show
+    @game = Game.find_by(code: params[:code])
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,16 @@
 class GamesController < ApplicationController
   def show
     @game = Game.find_by(code: params[:code])
+    region = Region.find_by(code: @game.region_code)
+    @title_for_tab =
+      @game.contest_nth.ordinalize + " " +
+      region.name[0, 1] + " " +
+      @game.round.to_s + "回戦" +
+      "第" + @game.game.to_s + "試合"
+    @title =
+      "第" + @game.contest_nth.to_s + "回 " +
+      region.name + "#{ @game.region_code >= 1 ? "地区" : "" }大会 " +
+      @game.round.to_s + "回戦 " +
+      "第" + @game.game.to_s + "試合"
   end
 end

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -1,0 +1,2 @@
+module GamesHelper
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,9 +1,10 @@
 class Game < ApplicationRecord
-  belongs_to :contest, foreign_key: :contest_nth,       primary_key: :nth
-  belongs_to :region,  foreign_key: :region_code,       primary_key: :code
-  belongs_to :robot,   foreign_key: :left_robot_code,   primary_key: :code
-  belongs_to :robot,   foreign_key: :right_robot_code,  primary_key: :code
-  belongs_to :robot,   foreign_key: :winner_robot_code, primary_key: :code
+  belongs_to :contest,     foreign_key: :contest_nth,       primary_key: :nth
+  belongs_to :region,      foreign_key: :region_code,       primary_key: :code
+  belongs_to :robot,       foreign_key: :left_robot_code,   primary_key: :code
+  belongs_to :robot,       foreign_key: :right_robot_code,  primary_key: :code
+  belongs_to :robot,       foreign_key: :winner_robot_code, primary_key: :code
+  has_one    :game_detail, foreign_key: :game_code,         primary_key: :code, dependent: :destroy
 
   validates :code,              presence: true, uniqueness: true
   validates :contest_nth,       presence: true

--- a/app/models/game_detail.rb
+++ b/app/models/game_detail.rb
@@ -1,3 +1,4 @@
 class GameDetail < ApplicationRecord
+  belongs_to :game, foreign_key: :game_code, primary_key: :code
   serialize :properties, JSON
 end

--- a/app/models/game_detail.rb
+++ b/app/models/game_detail.rb
@@ -1,0 +1,3 @@
+class GameDetail < ApplicationRecord
+  serialize :properties, JSON
+end

--- a/app/views/games/_details_for_29th.html.erb
+++ b/app/views/games/_details_for_29th.html.erb
@@ -1,0 +1,70 @@
+<div class="row">
+  <div class="col-lg-12">
+    <table>
+      <%
+        left_robot = Robot.joins(:campus).find_by(code: @game.left_robot_code)
+        right_robot = Robot.joins(:campus).find_by(code: @game.right_robot_code)
+        if @game.winner_robot_code != left_robot.code then # 左側を勝者に
+          left_robot, right_robot = right_robot, left_robot
+          winner_robot = left_robot
+        end
+        winner_score, looser_score = @game.game_detail.properties["score"].split("-")
+        if winner_score < looser_score then
+          winner_score, looser_score = looser_score, winner_score
+        end
+      %>
+      <tr>
+        <td align="center"><%= link_to left_robot.campus.abbreviation, campus_path(left_robot.campus.code) %></td>
+        <td></td>
+        <td align="center"><%= link_to right_robot.campus.abbreviation, campus_path(right_robot.campus.code) %></td>
+      </tr>
+      <tr>
+        <td><%= link_to left_robot.name, robot_path(left_robot.code) %></td>
+        <td align="center">&nbsp&nbspVS&nbsp&nbsp</td>
+        <td><%= link_to right_robot.name, robot_path(right_robot.code) %></td>
+      </tr>
+      <tr>
+        <td></td>
+        <td align="center">高さ</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="center"><%= winner_score %>cm</td>
+        <td></td>
+        <td align="center"><%= looser_score %>cm</td>
+      </tr>
+      <% if winner_score > looser_score then # draw %>
+      <tr>
+        <td><%= link_to left_robot.campus.abbreviation, campus_path(left_robot.campus.code) %>の勝ち</td>
+        <td></td>
+        <td></td>
+      </tr>
+      <% elsif winner_score == looser_score then # draw
+          winner_judge, looser_judge = @game.game_detail.properties["judges decision"].split("-")
+      %>
+      <tr>
+        <td></td>
+        <td align="center">審査員判定</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td align="center"><%= winner_judge %></td>
+        <td></td>
+        <td align="center"><%= looser_judge %></td>
+      </tr>
+      <tr>
+        <td></td>
+        <td align="center">
+          <%= link_to left_robot.campus.abbreviation, campus_path(left_robot.campus.code) %>の勝ち
+        </td>
+        <td></td>
+      </tr>
+      <% end %>
+    </table>
+    <% if not @game.game_detail.properties["memo"].blank? then %>
+      <h4>試合メモ</h4>
+      <%= @game.game_detail.properties["memo"] %>
+    <% end %>
+  </div>
+</div>
+<hr>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,15 +1,5 @@
-<% provide(:title, @game.round.to_s+"回戦 第"+@game.game.to_s+"試合") %>
+<% provide(:title, @title_for_tab) %>
 
-<%= render "shared/title", title: (yield :title) %>
+<%= render "shared/title", title: @title %>
 
-<div class="row">
-  <div class="col-lg-12">
-    <%
-      score = @game.game_detail.properties["score"]
-    %>
-    <tr>
-      <td>スコア</td>
-      <td><%= score %></td>
-    </tr>
-  </div>
-</div>
+<%= render "games/details_for_" + @game.contest.nth.ordinalize %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,0 +1,15 @@
+<% provide(:title, @game.round.to_s+"回戦 第"+@game.game.to_s+"試合") %>
+
+<%= render "shared/title", title: (yield :title) %>
+
+<div class="row">
+  <div class="col-lg-12">
+    <%
+      score = @game.game_detail.properties["score"]
+    %>
+    <tr>
+      <td>スコア</td>
+      <td><%= score %></td>
+    </tr>
+  </div>
+</div>

--- a/app/views/robots/show.html.erb
+++ b/app/views/robots/show.html.erb
@@ -43,7 +43,7 @@
           %>
           <tr>
             <td><%= game.region.name %></td>
-            <td><%= game.round %>回戦　第<%= game.game %>試合</td>
+            <td><%= link_to game.round.to_s+"回戦 第"+game.game.to_s+"試合", game_path(game.code) %></td>
             <td><%= link_to opponent.campus.abbreviation, campus_path(opponent.campus.code) %></td>
             <td><%= link_to opponent.name, robot_path(opponent.code) %></td>
             <td><%= opponent.code != game.winner_robot_code ? "勝ち" : "負け" %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,13 @@
 Rails.application.routes.draw do
 
+  get 'games/show'
+
   root 'static_pages#home'
 
   resources :campuses, only: [:index, :show], param: :code
   resources :contests, only: [:index, :show], param: :nth
   resources :contest_entries, only: [:index]
   resources :robots, only: [:show], param: :code
+  resources :games, only: [:show], param: :code
 
 end

--- a/db/migrate/20170328091957_create_game_details.rb
+++ b/db/migrate/20170328091957_create_game_details.rb
@@ -1,0 +1,11 @@
+class CreateGameDetails < ActiveRecord::Migration[5.0]
+  def change
+    create_table :game_details do |t|
+      t.integer :game_code, null: false
+      t.integer :number, default: 1, null: false
+      t.text :properties
+      t.timestamps
+      t.index ["game_code", "number"], name: "index_game_details_on_game_code_and_number"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-ActiveRecord::Schema.define(version: 20170328091957) do
-=======
 ActiveRecord::Schema.define(version: 20170402003007) do
->>>>>>> refs/remotes/origin/master
 
   create_table "campus_histories", force: :cascade do |t|
     t.integer  "campus_code",  null: false
@@ -62,11 +58,12 @@ ActiveRecord::Schema.define(version: 20170402003007) do
   end
 
   create_table "game_details", force: :cascade do |t|
-    t.integer  "game_code",  null: false
+    t.integer  "game_code",              null: false
+    t.integer  "number",     default: 1, null: false
     t.text     "properties"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["game_code"], name: "index_game_details_on_game_code", unique: true
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.index ["game_code", "number"], name: "index_game_details_on_game_code_and_number"
   end
 
   create_table "games", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170323080622) do
+ActiveRecord::Schema.define(version: 20170328091957) do
 
   create_table "campus_histories", force: :cascade do |t|
     t.integer  "campus_code",  null: false
@@ -55,6 +55,14 @@ ActiveRecord::Schema.define(version: 20170323080622) do
     t.datetime "updated_at", null: false
     t.index ["nth"], name: "index_contests_on_nth", unique: true
     t.index ["year"], name: "index_contests_on_year"
+  end
+
+  create_table "game_details", force: :cascade do |t|
+    t.integer  "game_code",  null: false
+    t.text     "properties"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_code"], name: "index_game_details_on_game_code", unique: true
   end
 
   create_table "games", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@
 RobotCondition.delete_all
 PrizeHistory.delete_all
 Prize.delete_all
-GameDetails.delete_all
+GameDetail.delete_all
 Game.delete_all
 Robot.delete_all
 CampusHistory.delete_all
@@ -26,7 +26,7 @@ load(File.join(Rails.root, 'db', 'seeds', 'contest_entry.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'campus_history.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'robot.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'game.rb'))
-load(File.join(Rails.root, 'db', 'seeds', 'game_details.rb'))
+load(File.join(Rails.root, 'db', 'seeds', 'game_detail.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'prize.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'prize_history.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'robot_condition.rb'))

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,7 @@
 RobotCondition.delete_all
 PrizeHistory.delete_all
 Prize.delete_all
+GameDetails.delete_all
 Game.delete_all
 Robot.delete_all
 CampusHistory.delete_all
@@ -25,6 +26,7 @@ load(File.join(Rails.root, 'db', 'seeds', 'contest_entry.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'campus_history.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'robot.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'game.rb'))
+load(File.join(Rails.root, 'db', 'seeds', 'game_details.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'prize.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'prize_history.rb'))
 load(File.join(Rails.root, 'db', 'seeds', 'robot_condition.rb'))

--- a/db/seeds/game_detail.rb
+++ b/db/seeds/game_detail.rb
@@ -1,0 +1,13 @@
+# see game.rb and http://www.nhk.or.jp/robocon/rbcn2016/result.html
+# Game.create(code: 1291101, contest_nth: 29, region_code: 1, round: 1, game: 1, left_robot_code: 129110401, right_robot_code: 129110502, winner_robot_code: 129110502)
+# Game.create(code: 1291102, contest_nth: 29, region_code: 1, round: 1, game: 2, left_robot_code: 129110102, right_robot_code: 129110201, winner_robot_code: 129110201)
+# Game.create(code: 1291103, contest_nth: 29, region_code: 1, round: 1, game: 3, left_robot_code: 129110402, right_robot_code: 129110101, winner_robot_code: 129110101)
+# Game.create(code: 1291104, contest_nth: 29, region_code: 1, round: 1, game: 4, left_robot_code: 129110202, right_robot_code: 129110501, winner_robot_code: 129110501)
+# Game.create(code: 1291201, contest_nth: 29, region_code: 1, round: 2, game: 1, left_robot_code: 129110502, right_robot_code: 129110201, winner_robot_code: 129110201)
+# Game.create(code: 1291202, contest_nth: 29, region_code: 1, round: 2, game: 2, left_robot_code: 129110101, right_robot_code: 129110501, winner_robot_code: 129110101)
+# Game.create(code: 1291301, contest_nth: 29, region_code: 1, round: 3, game: 1, left_robot_code: 129110201, right_robot_code: 129110101, winner_robot_code: 129110101)
+
+GameDetail.create(game_code: 1291101, properties: "
+  
+
+")

--- a/db/seeds/game_detail.rb
+++ b/db/seeds/game_detail.rb
@@ -8,23 +8,15 @@
 # Game.create(code: 1291301, contest_nth: 29, region_code: 1, round: 3, game: 1, left_robot_code: 129110201, right_robot_code: 129110101, winner_robot_code: 129110101)
 
 GameDetail.create(game_code: 1291101, properties: {
-  "スコア":"0-0",
   "score":"0-0",
-  "審査員判定":"3-0",
   "judges decision":"3-0",
-  "勝者達成課題":"灯台",
   "winner progress":"灯台",
-  "敗者達成課題":"なし",
   "loser progress":"なし"
 })
 GameDetail.create(game_code: 1291102, properties: {
-  "スコア":"0-0",
   "score":"0-0",
-  "審査員判定":"2-1",
   "judges decision":"2-1",
-  "勝者達成課題":"灯台",
   "winner progress":"灯台",
-  "敗者達成課題":"灯台",
   "loser progress":"灯台",
-  "memo":"釧路は灯台完成が早かった。"
+  "memo":"釧路は旭川より灯台完成が早かった。"
 })

--- a/db/seeds/game_detail.rb
+++ b/db/seeds/game_detail.rb
@@ -7,7 +7,24 @@
 # Game.create(code: 1291202, contest_nth: 29, region_code: 1, round: 2, game: 2, left_robot_code: 129110101, right_robot_code: 129110501, winner_robot_code: 129110101)
 # Game.create(code: 1291301, contest_nth: 29, region_code: 1, round: 3, game: 1, left_robot_code: 129110201, right_robot_code: 129110101, winner_robot_code: 129110101)
 
-GameDetail.create(game_code: 1291101, properties: "
-  
-
-")
+GameDetail.create(game_code: 1291101, properties: {
+  "スコア":"0-0",
+  "score":"0-0",
+  "審査員判定":"3-0",
+  "judges decision":"3-0",
+  "勝者達成課題":"灯台",
+  "winner progress":"灯台",
+  "敗者達成課題":"なし",
+  "loser progress":"なし"
+})
+GameDetail.create(game_code: 1291102, properties: {
+  "スコア":"0-0",
+  "score":"0-0",
+  "審査員判定":"2-1",
+  "judges decision":"2-1",
+  "勝者達成課題":"灯台",
+  "winner progress":"灯台",
+  "敗者達成課題":"灯台",
+  "loser progress":"灯台",
+  "memo":"釧路は灯台完成が早かった。"
+})

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class GamesControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get games_show_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/game_details.yml
+++ b/test/fixtures/game_details.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  game_code: 1
+
+two:
+  game_code: 1

--- a/test/models/game_detail_test.rb
+++ b/test/models/game_detail_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GameDetailTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
試合の詳細を表示する機能を追加。
seedおよび対応する試合ルールはこの時点では第29回大会しかない（大会毎に異なるため、逐次対応予定）。
