### PR TITLE
ロボット情報表示順変更と第２９回大会の審査員判定の最大値変更

### DIFF
--- a/app/models/game_details/game_detail29th.rb
+++ b/app/models/game_details/game_detail29th.rb
@@ -12,10 +12,10 @@ class GameDetail29th < GameDetail
   # validates :judge,             inclusion: { in: ["true", "false"] }
   with_options if: :judge do
     validates :judge_to_me,       numericality: {
-      only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 3
+      only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 5
     }
     validates :judge_to_opponent, numericality: {
-      only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 3
+      only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 5
     }
   end
   with_options if: :progress do

--- a/app/views/robots/show.html.erb
+++ b/app/views/robots/show.html.erb
@@ -131,6 +131,7 @@
 
 <div class="row">
   <div class="col-lg-12">
+    <h4>現存情報</h4>
     <% if !@robot.robot_condition.blank? then %>
     <div align="right">
       <%= link_to fa_icon("pencil-square", text:"編集"), edit_robot_robot_conditions_path(@robot.code) %>

--- a/app/views/robots/show.html.erb
+++ b/app/views/robots/show.html.erb
@@ -24,57 +24,58 @@
 
 <div class="row">
   <div class="col-lg-12">
-    <% if !@robot.robot_condition.blank? then %>
+    <h4>全国大会進出情報</h4>
+    <% if !@robot.advancement_history.blank? then %>
     <div align="right">
-      <%= link_to fa_icon("pencil-square", text:"編集"), edit_robot_robot_conditions_path(@robot.code) %>
+      <%=
+        link_to fa_icon("pencil-square", text:"編集"),
+        edit_robot_advancement_history_path(@robot.code)
+      %>
       または
-      <%= link_to fa_icon("trash", text:"逸失に変更"),
-        robot_robot_conditions_path(@robot.code), :method => :delete,
-        data: {confirm: "逸失に変更しますか？"} %>
+      <%=
+        link_to fa_icon("trash", text:"削除"),
+        robot_advancement_history_path(@robot.code), :method => :delete,
+        data: {confirm: "削除しますか？"}
+      %>
     </div>
     <% else %>
-    <div align="right"><%= link_to fa_icon("pencil-square-o", text:"現存に変更"), new_robot_robot_conditions_path(@robot.code) %></div>
+    <div align="right"><%=
+      link_to fa_icon("pencil-square-o", text:"新規作成"),
+      new_robot_advancement_history_path(@robot.code)
+    %></div>
     <% end %>
     <table class="table table-striped table-condensed">
       <tbody>
+        <% if !@robot.advancement_history.blank? then %>
         <tr>
-          <td>現況：</td>
-          <% if !@robot.robot_condition.blank? then %>
-          <td>現存</td>
-          <% else %>
-          <td>逸失</td>
-          <% end %>
+          <td>進出ケース：</td>
+          <td><%=
+            Advancement.find_by(
+              case: @robot.advancement_history.advancement_case
+            ).case_name
+          %></td>
         </tr>
-        <% if !@robot.robot_condition.blank? then %>
+        <% if @robot.advancement_history.decline then %>
         <tr>
           <td></td>
-          <% if @robot.robot_condition.fully_operational then %>
-          <td>動態保存</td>
-          <% else %>
-          <td>静態保存</td>
-          <% end %>
+          <td>全国進出を辞退</td>
         </tr>
+        <% end %>
         <tr>
-          <td></td>
-          <% if !@robot.robot_condition.restoration then %>
-          <td>オリジナル</td>
-          <% else %>
-          <td>復刻</td>
-          <% end %>
+          <td>メモ：</td>
+          <td><%= @robot.advancement_history.memo %></td>
         </tr>
+        <% else %>
         <tr>
-          <td></td>
-          <% if !@robot.robot_condition.memo.blank? then %>
-          <td><%= @robot.robot_condition.memo %></td>
-          <% else %>
-          <td></td>
-          <% end %>
+          <td colspan=2>未登録</td>
         </tr>
         <% end %>
       </tbody>
     </table>
   </div>
 </div>
+
+<%= render "prize_histories/prize_histories", prize_histories: @prize_histories %>
 
 <div class="row">
   <div class="col-lg-12">
@@ -128,57 +129,53 @@
   </div>
 </div>
 
-<%= render "prize_histories/prize_histories", prize_histories: @prize_histories %>
-
 <div class="row">
   <div class="col-lg-12">
-    <h4>全国大会進出情報</h4>
-    <% if !@robot.advancement_history.blank? then %>
+    <% if !@robot.robot_condition.blank? then %>
     <div align="right">
-      <%=
-        link_to fa_icon("pencil-square", text:"編集"),
-        edit_robot_advancement_history_path(@robot.code)
-      %>
+      <%= link_to fa_icon("pencil-square", text:"編集"), edit_robot_robot_conditions_path(@robot.code) %>
       または
-      <%=
-        link_to fa_icon("trash", text:"削除"),
-        robot_advancement_history_path(@robot.code), :method => :delete,
-        data: {confirm: "削除しますか？"}
-      %>
+      <%= link_to fa_icon("trash", text:"逸失に変更"),
+        robot_robot_conditions_path(@robot.code), :method => :delete,
+        data: {confirm: "逸失に変更しますか？"} %>
     </div>
     <% else %>
-    <div align="right"><%=
-      link_to fa_icon("pencil-square-o", text:"新規作成"),
-      new_robot_advancement_history_path(@robot.code)
-    %></div>
+    <div align="right"><%= link_to fa_icon("pencil-square-o", text:"現存に変更"), new_robot_robot_conditions_path(@robot.code) %></div>
     <% end %>
     <table class="table table-striped table-condensed">
       <tbody>
-        <% if !@robot.advancement_history.blank? then %>
         <tr>
-          <td>進出ケース</td>
-          <td>:</td>
-          <td><%=
-            Advancement.find_by(
-              case: @robot.advancement_history.advancement_case
-            ).case_name
-          %></td>
+          <td>現況：</td>
+          <% if !@robot.robot_condition.blank? then %>
+          <td>現存</td>
+          <% else %>
+          <td>逸失</td>
+          <% end %>
         </tr>
-        <% if @robot.advancement_history.decline then %>
+        <% if !@robot.robot_condition.blank? then %>
         <tr>
           <td></td>
+          <% if @robot.robot_condition.fully_operational then %>
+          <td>動態保存</td>
+          <% else %>
+          <td>静態保存</td>
+          <% end %>
+        </tr>
+        <tr>
           <td></td>
-          <td>全国進出を辞退</td>
+          <% if !@robot.robot_condition.restoration then %>
+          <td>オリジナル</td>
+          <% else %>
+          <td>復刻</td>
+          <% end %>
         </tr>
-        <% end %>
         <tr>
-          <td>メモ</td>
-          <td>:</td>
-          <td><%= @robot.advancement_history.memo %></td>
-        </tr>
-        <% else %>
-        <tr>
-          <td colspan=3>未登録</td>
+          <td></td>
+          <% if !@robot.robot_condition.memo.blank? then %>
+          <td><%= @robot.robot_condition.memo %></td>
+          <% else %>
+          <td></td>
+          <% end %>
         </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
ロボット情報表示順変更はビュー内のソースを入れ替えただけ。
審査員判定の最大値は全国か地区大会かによらず最大値を５にしただけ。