### PR TITLE
fix: Twitterログインできないバグを修正

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   Devise.setup do |config|
-    config.omniauth :twitter, 'k4FcdCGDOX3feXXm7F7QbESnc', 'TArUyPOanxfprD5tiC0TdZ0y5mQ2HdFrYuSvztyrkT45JMvkzm', :display => 'popup'
+    config.omniauth :twitter, 'k4FcdCGDOX3feXXm7F7QbESnc', 'TArUyPOanxfprD5tiC0TdZ0y5mQ2HdFrYuSvztyrkT45JMvkzm', :display => 'popup', callback_url: "http://localhost:3000/auth/twitter/callback"
   end
   # Devise.setup do |config|
   #   config.omniauth :twitter,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   Devise.setup do |config|
-    config.omniauth :twitter, 'byyWb71tt3FLrj2uoBStlCoIa', 'aSFumRp8V5JMWl1c1tDyK1T1BYOasME5qN0vKiqoSixDD5sVa7', :display => 'popup'
+    config.omniauth :twitter, 'byyWb71tt3FLrj2uoBStlCoIa', 'aSFumRp8V5JMWl1c1tDyK1T1BYOasME5qN0vKiqoSixDD5sVa7', :display => 'popup', callback_url: "http://kosen-robocon-db.herokuapp.com/auth/twitter/callback"
   end
   # Devise.setup do |config|
   #   config.omniauth :twitter,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   Devise.setup do |config|
-    config.omniauth :twitter, 'awoD7k5nmGywyAJjg6Qrrs4Xa', 'psrqbse1xVNeHNIaMJgFU2itaVjnr9AaoKpPRNpTWGYb5YQeLX', :display => 'popup'
+    config.omniauth :twitter, 'awoD7k5nmGywyAJjg6Qrrs4Xa', 'psrqbse1xVNeHNIaMJgFU2itaVjnr9AaoKpPRNpTWGYb5YQeLX', :display => 'popup', callback_url: "http://kosen-robocon-db-staging.herokuapp.com/auth/twitter/callback"
   end
   # Devise.setup do |config|
   #   config.omniauth :twitter,

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   Devise.setup do |config|
-    config.omniauth :twitter, 'k4FcdCGDOX3feXXm7F7QbESnc', 'TArUyPOanxfprD5tiC0TdZ0y5mQ2HdFrYuSvztyrkT45JMvkzm', :display => 'popup'
+    config.omniauth :twitter, 'k4FcdCGDOX3feXXm7F7QbESnc', 'TArUyPOanxfprD5tiC0TdZ0y5mQ2HdFrYuSvztyrkT45JMvkzm', :display => 'popup', callback_url: "http://localhost:3000/auth/twitter/callback"
   end
   # Devise.setup do |config|
   #   config.omniauth :twitter,


### PR DESCRIPTION
Twitterログインできないバグを修正しました。

Twitterの仕様変更により可変URL `kosen-robocon-db-stagin-pr-XXX` でのログインはできなくなりましたので、今後、ログインが必要なものはstagingで確認することになります。

参考：https://qiita.com/gifu_w/items/41d2c868317edea5045b